### PR TITLE
Serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 chrono = "0.3"
+serde = { version = "1", optional = true }
 
 [build-dependencies]
 parse-zoneinfo = "0.1"
+
+[dev-dependencies]
+serde_test = "1"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ assert_eq!(utc.to_string(), "2016-10-21 23:00:00 UTC");
 
 ## Future Improvements
 
-- `rustc-serialize` and `serde` support.
 - Handle leap seconds
 - Handle Julian to Gregorian calendar transitions
 - Load tzdata always from latest version

--- a/build.rs
+++ b/build.rs
@@ -82,7 +82,7 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) {
                raw_zone_name = zone).unwrap();
     }
     write!(timezone_file,
-"             s => Err(s.to_string())
+"             s => Err(format!(\"'{{}}' is not a valid timezone\", s.to_string()))
         }}
     }}
 }}\n\n").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,13 @@
 //! ```toml
 //! [dependencies]
 //! chrono = "0.3"
-//! chrono-tz = "0.3"
+//! chrono-tz = "0.3.3"
+//! ```
+//!
+//! If you want Serde support, specify it like this:
+//!
+//! ```toml
+//! chrono-tz = { version = "0.3.3", features = ["serde"] }
 //! ```
 //!
 //! Then you will need to write (in your crate root):
@@ -140,6 +146,9 @@
 //! ```
 
 extern crate chrono;
+
+#[cfg(feature = "serde")]
+mod serde;
 
 mod timezone_impl;
 mod binary_search;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,53 @@
+extern crate serde;
+
+use std::fmt;
+use self::serde::{de, Serialize, Serializer, Deserialize, Deserializer};
+
+use timezones::Tz;
+
+impl Serialize for Tz {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.name())
+    }
+}
+
+impl<'de> Deserialize<'de> for Tz {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Tz;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "an IANA timezone string")
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Tz, E> {
+                value.parse::<Tz>().map_err(|e| E::custom(e.to_string()))
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate serde_test;
+
+    use self::serde_test::{Token, assert_tokens, assert_de_tokens_error};
+    use timezones::Tz::{self, Europe__London, Etc__UTC, UTC};
+
+    #[test]
+    fn serde_ok_both_ways() {
+        assert_tokens(&Europe__London, &[Token::String("Europe/London")]);
+        assert_tokens(&Etc__UTC, &[Token::String("Etc/UTC")]);
+        assert_tokens(&UTC, &[Token::String("UTC")]);
+    }
+
+    #[test]
+    fn serde_de_error() {
+        assert_de_tokens_error::<Tz>(&[Token::Str("Europe/L")], "'Europe/L' is not a valid timezone");
+        assert_de_tokens_error::<Tz>(&[Token::Str("")], "'' is not a valid timezone");
+    }
+}


### PR DESCRIPTION
Also upped the version number in the Cargo.toml example in the docs since Serde wasn't added until now.

rustc-serialize is officially deprecated in favor of Serde so took the whole line off the checklist as well.