### PR TITLE
Updates Chrono to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Djzin"]
 build = "build.rs"
 description = "TimeZone implementations for rust-chrono from the IANA database"
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-chrono = "0.3"
+chrono = "0.4"
 
 [build-dependencies]
 parse-zoneinfo = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! chrono = "0.3"
-//! chrono-tz = "0.3"
+//! chrono = "0.4"
+//! chrono-tz = "0.4"
 //! ```
 //!
 //! Then you will need to write (in your crate root):
@@ -34,13 +34,13 @@
 //! ```
 //! # extern crate chrono;
 //! # extern crate chrono_tz;
-//! use chrono::{TimeZone, UTC};
+//! use chrono::{TimeZone, Utc};
 //! use chrono_tz::US::Pacific;
 //!
 //! # fn main() {
 //! let pacific_time = Pacific.ymd(1990, 5, 6).and_hms(12, 30, 45);
-//! let utc_time = pacific_time.with_timezone(&UTC);
-//! assert_eq!(utc_time, UTC.ymd(1990, 5, 6).and_hms(19, 30, 45));
+//! let utc_time = pacific_time.with_timezone(&Utc);
+//! assert_eq!(utc_time, Utc.ymd(1990, 5, 6).and_hms(19, 30, 45));
 //! # }
 //! ```
 //!


### PR DESCRIPTION
Bumps the Chrono depenancy to 0.4 and renames the required tests.

In 0.4, Chrono changed its UTC type to Utc. I don't know why this change was made, so I didn't change all the UTCs in this crate. If there is a need to change the name, then this pull request should be canceled and a new one with the name change included.