### PR TITLE
Fix Utc example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ extern crate chrono_tz;
 Create a time in one timezone and convert it to UTC
 
 ```rust
-use chrono::{TimeZone, UTC};
+use chrono::{TimeZone, Utc};
 use chrono_tz::US::Pacific;
 
 let pacific_time = Pacific.ymd(1990, 5, 6).and_hms(12, 30, 45);
-let utc_time = pacific_time.with_timezone(&UTC);
-assert_eq!(utc_time, UTC.ymd(1990, 5, 6).and_hms(19, 30, 45));
+let utc_time = pacific_time.with_timezone(&Utc);
+assert_eq!(utc_time, Utc.ymd(1990, 5, 6).and_hms(19, 30, 45));
 ```
 
 Create a naive datetime and convert it to a timezone-aware datetime


### PR DESCRIPTION
Example of converting to `Utc` from the README doesn't compile:
```rust
use chrono::{TimeZone, UTC};
use chrono_tz::US::Pacific;

pub fn test() {
    let pacific_time = Pacific.ymd(1990, 5, 6).and_hms(12, 30, 45);
    let utc_time = pacific_time.with_timezone(&UTC);
    assert_eq!(utc_time, UTC.ymd(1990, 5, 6).and_hms(19, 30, 45));
}
```

```rust
error[E0432]: unresolved import `chrono::UTC`
 --> src/test.rs:1:24
  |
1 | use chrono::{TimeZone, UTC};
  |                        ^^^ no `UTC` in the root

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
```

This changes `chrono::UTC` -> `chrono::Utc`;