### PR TITLE
Opt-out of the default-features of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 serde = { version = "1", optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
`chrono-tz` does not depend on the system clock or local timezone, so we could opt-out of `chrono`'s default features.