### PR TITLE
Support no_std usage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,9 +3,16 @@ name: Rust
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            run_no_std: true
+
+    runs-on: ${{ matrix.os }}
 
     env:
       RUST_BACKTRACE: 1
@@ -18,7 +25,29 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-    - name: Build
-      run: cargo build --verbose --color=always
     - name: Run tests
-      run: cargo test --verbose --color=always -- --color=always
+      run: cargo test --color=always -- --color=always
+    - name: Run tests serde
+      run: cargo test --features serde --color=always -- --color=always
+    - name: Check with no default features
+      run: cargo check --no-default-features --color=always
+
+    - name: Install no_std toolchain
+      if: ${{ matrix.run_no_std }}
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        target: thumbv7m-none-eabi
+    - name: Verify builds on no_std no features
+      if: ${{ matrix.run_no_std }}
+      working-directory: ./tests/check-nostd
+      run: |
+        cargo clean
+        cargo build --no-default-features
+    - name: Verify builds on no_std with serde
+      if: ${{ matrix.run_no_std }}
+      working-directory: ./tests/check-nostd
+      run: |
+        cargo clean
+        cargo build --features serde1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false }
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, default-features = false }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ license = "MIT/Apache-2.0"
 chrono = { version = "0.4", default-features = false }
 serde = { version = "1", optional = true }
 
+[features]
+default = ["std"]
+std = []
+
 [build-dependencies]
 parse-zoneinfo = { version = "0.3" }
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ let utc = dt.with_timezone(&UTC);
 assert_eq!(utc.to_string(), "2016-10-21 23:00:00 UTC");
 ```
 
+## `no_std` Support
+
+To use this library without depending on the Rust standard library, put this
+in your `Cargo.toml`:
+```toml
+[dependencies]
+chrono = { version = "0.4", default-features = false }
+chrono-tz = { version = "0.5", default-features = false }
+```
+
+If you are using this library in an environment with limited program
+space, such as a microcontroller, take note that you will also likely
+need to enable optimizations and Link Time Optimization:
+```toml
+[profile.dev]
+opt-level = 2
+lto = true
+
+[profile.release]
+lto = true
+```
+
+Otherwise, the additional binary size added by this library may overflow
+available program space and trigger a linker error.
+
 ## Future Improvements
 
 - Handle leap seconds

--- a/build.rs
+++ b/build.rs
@@ -60,13 +60,7 @@ fn convert_bad_chars(name: &str) -> String {
 fn write_timezone_file(timezone_file: &mut File, table: &Table) {
     let zones = table.zonesets.keys().chain(table.links.keys()).collect::<BTreeSet<_>>();
     write!(timezone_file, "use ::timezone_impl::{{TimeSpans, FixedTimespanSet, FixedTimespan}};\n",).unwrap();
-    write!(timezone_file, "#[cfg(feature = \"std\")]\n",).unwrap();
-    write!(timezone_file, "use std::fmt::{{Debug, Formatter, Error}};\n\n",).unwrap();
-    write!(timezone_file, "#[cfg(feature = \"std\")]\n",).unwrap();
-    write!(timezone_file, "use std::str::FromStr;\n\n",).unwrap();
-    write!(timezone_file, "#[cfg(not(feature = \"std\"))]\n",).unwrap();
     write!(timezone_file, "use core::fmt::{{Debug, Formatter, Error}};\n\n",).unwrap();
-    write!(timezone_file, "#[cfg(not(feature = \"std\"))]\n",).unwrap();
     write!(timezone_file, "use core::str::FromStr;\n\n",).unwrap();
     write!(timezone_file, "#[derive(Clone, Copy, PartialEq, Eq, Hash)]\npub enum Tz {{\n").unwrap();
     for zone in &zones {

--- a/src/binary_search.rs
+++ b/src/binary_search.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "std")]
-use std::cmp::Ordering;
-#[cfg(not(feature = "std"))]
 use core::cmp::Ordering;
 
 /// An implementation of binary search on indices only

--- a/src/binary_search.rs
+++ b/src/binary_search.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "std")]
 use std::cmp::Ordering;
+#[cfg(not(feature = "std"))]
+use core::cmp::Ordering;
 
 /// An implementation of binary search on indices only
 /// that does not require slices to be constructed. Mirrors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,12 +144,14 @@
 //! assert_eq!(utc.to_string(), "2016-10-21 23:00:00 UTC");
 //! # }
 //! ```
-//! 
+//!
 //! If you need to iterate over all variants you can use the TZ_VARIANTS array
 //! ```
 //! use chrono_tz::{TZ_VARIANTS, Tz};
 //! assert!(TZ_VARIANTS.iter().any(|v| *v == Tz::UTC));
 //! ```
+
+#![cfg_attr(not(feature="std"), no_std)]
 
 extern crate chrono;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,9 @@
 
 #![cfg_attr(not(feature="std"), no_std)]
 
+#[cfg(feature = "std")]
+extern crate std as core;
+
 extern crate chrono;
 
 #[cfg(feature = "serde")]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,6 +1,6 @@
 extern crate serde;
 
-use std::fmt;
+use core::fmt;
 use self::serde::{de, Serialize, Serializer, Deserialize, Deserializer};
 
 use timezones::Tz;
@@ -23,7 +23,7 @@ impl<'de> Deserialize<'de> for Tz {
             }
 
             fn visit_str<E: de::Error>(self, value: &str) -> Result<Tz, E> {
-                value.parse::<Tz>().map_err(|e| E::custom(e.to_string()))
+                value.parse::<Tz>().map_err(|e| E::custom(e))
             }
         }
 

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -1,6 +1,12 @@
 use chrono::{Offset, TimeZone, NaiveDate, NaiveDateTime, LocalResult, FixedOffset};
+#[cfg(feature = "std")]
 use std::fmt::{Debug, Display, Formatter, Error};
+#[cfg(feature = "std")]
 use std::cmp::Ordering;
+#[cfg(not(feature = "std"))]
+use core::fmt::{Debug, Display, Formatter, Error};
+#[cfg(not(feature = "std"))]
+use core::cmp::Ordering;
 use binary_search::binary_search;
 use super::timezones::Tz;
 

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -1,11 +1,5 @@
 use chrono::{Offset, TimeZone, NaiveDate, NaiveDateTime, LocalResult, FixedOffset};
-#[cfg(feature = "std")]
-use std::fmt::{Debug, Display, Formatter, Error};
-#[cfg(feature = "std")]
-use std::cmp::Ordering;
-#[cfg(not(feature = "std"))]
 use core::fmt::{Debug, Display, Formatter, Error};
-#[cfg(not(feature = "std"))]
 use core::cmp::Ordering;
 use binary_search::binary_search;
 use super::timezones::Tz;

--- a/tests/check-nostd/.cargo/config
+++ b/tests/check-nostd/.cargo/config
@@ -1,0 +1,9 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+
+rustflags = [
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7m-none-eabi"

--- a/tests/check-nostd/.gitignore
+++ b/tests/check-nostd/.gitignore
@@ -1,0 +1,4 @@
+**/*.rs.bk
+.#*
+Cargo.lock
+target/

--- a/tests/check-nostd/Cargo.toml
+++ b/tests/check-nostd/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
+edition = "2018"
+readme = "README.md"
+name = "check-nostd"
+version = "0.1.0"
+
+[dependencies]
+cortex-m-rt = "0.6.10"
+chrono-tz = { path = "../../", default-features = false }
+
+[features]
+serde1 = ["chrono-tz/serde"]

--- a/tests/check-nostd/memory.x
+++ b/tests/check-nostd/memory.x
@@ -1,0 +1,34 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* TODO Adjust these memory regions to match your device memory layout */
+  /* These values correspond to the LM3S6965, one of the few devices QEMU can emulate */
+  FLASH : ORIGIN = 0x00000000, LENGTH = 256K
+  RAM : ORIGIN = 0x20000000, LENGTH = 64K
+}
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* You may want to use this variable to locate the call stack and static
+   variables in different memory regions. Below is shown the default value */
+/* _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* You can use this symbol to customize the location of the .text section */
+/* If omitted the .text section will be placed right after the .vector_table
+   section */
+/* This is required only on microcontrollers that store some configuration right
+   after the vector table */
+/* _stext = ORIGIN(FLASH) + 0x400; */
+
+/* Example of putting non-initialized variables into custom RAM locations. */
+/* This assumes you have defined a region RAM2 above, and in the Rust
+   sources added the attribute `#[link_section = ".ram2bss"]` to the data
+   you want to place there. */
+/* Note that the section will not be zero-initialized by the runtime! */
+/* SECTIONS {
+     .ram2bss (NOLOAD) : ALIGN(4) {
+       *(.ram2bss);
+       . = ALIGN(4);
+     } > RAM2
+   } INSERT AFTER .bss;
+*/

--- a/tests/check-nostd/src/main.rs
+++ b/tests/check-nostd/src/main.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+use chrono_tz::US::Pacific;
+use cortex_m_rt::entry;
+
+#[panic_handler]
+fn catch_panic(_e: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[entry]
+fn main() -> ! {
+    assert!(Pacific == Pacific);
+
+    loop {}
+}


### PR DESCRIPTION
The only significant change necessary for this (AFAICT) was changing the error on `Tz::from_str` to be less useful in no_std mode.

This can probably be improved, but I'm a relative beginner at Rust.

~~`parse-zoneinfo` was bumped from a non-existent branch to current master, where that branch was merged.~~ Merge conflict resolved. I'd squash this into one commit if I knew how to work git properly.