### PR TITLE
cargo: Fix build dependency parse-zoneinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ chrono = { version = "0.4", default-features = false }
 serde = { version = "1", optional = true }
 
 [build-dependencies]
-parse-zoneinfo = { git = "https://github.com/chronotope/parse-zoneinfo.git", branch = "support-overflowing-weekdays" }
+parse-zoneinfo = { git = "https://github.com/chronotope/parse-zoneinfo.git" }
 
 [dev-dependencies]
 serde_test = "1"


### PR DESCRIPTION
The upstream branch "support-overflowing-weekdays" is no longer alive, and was merged into master.