### PR TITLE
Impl Display for Tz

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,7 +63,7 @@ fn convert_bad_chars(name: &str) -> String {
 // TimeZone for any contained struct that implements `Timespans`.
 fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()> {
     let zones = table.zonesets.keys().chain(table.links.keys()).collect::<BTreeSet<_>>();
-    writeln!(timezone_file, "use core::fmt::{{Debug, Formatter, Error}};",)?;
+    writeln!(timezone_file, "use core::fmt::{{self, Debug, Display, Formatter}};",)?;
     writeln!(timezone_file, "use core::str::FromStr;\n",)?;
     writeln!(
         timezone_file,
@@ -143,8 +143,16 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()
     writeln!(
         timezone_file,
         "impl Debug for Tz {{
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {{
-        write!(f, \"{{}}\", self.name())
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {{
+        f.write_str(self.name().as_ref())
+    }}
+}}\n"
+    )?;
+    writeln!(
+        timezone_file,
+        "impl Display for Tz {{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {{
+        f.write_str(self.name().as_ref())
     }}
 }}\n"
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,6 +407,14 @@ mod tests {
     }
 
     #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", London), "Europe/London");
+        assert_eq!(format!("{}", Tz::Africa__Abidjan), "Africa/Abidjan");
+        assert_eq!(format!("{}", Tz::UTC), "UTC");
+        assert_eq!(format!("{}", Tz::Zulu), "Zulu");
+    }
+
+    #[test]
     fn test_impl_hash() {
         #[allow(dead_code)]
         #[derive(Hash)]


### PR DESCRIPTION
There is a`std::fmt::Debug` implementation but no `std::fmt::Display`.

it would allow a Tz to be passed to a function that takes a `std::fmt::Display` or `std::string::ToString`

```rust
use chrono_tz::Europe::Paris;
use std::string::ToString;

fn main() {
    println!("{}", takes_tostring(&Paris));
    println!("{}", takes_tostring("Hello"));
}

fn takes_tostring<T: ToString + ?Sized>(v: &T) -> String {
    format!("I am {}", v.to_string())
}
```

fixes #31 