### PR TITLE
[build.rs] make build.rs generate files relative to CARGO_MANIFEST_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -302,6 +302,7 @@ fn main() {
     let lines = tzfiles
         .iter()
         .map(Path::new)
+        .map(|p| Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap_or("".to_string())).join(p))
         .map(File::open)
         .map(Result::unwrap)
         .map(BufReader::new)


### PR DESCRIPTION
Currently, the build script `build.rs` makes an assumption about where the `tzfiles` live.  The assumption is that the files are in the same directory as the build script in order to read these files.  This is probably true in a lot of cases; However, a slightly more robust way would be to use the environment variable `CARGO_MANIFEST_DIR` that could be read about [here](https://doc.rust-lang.org/cargo/reference/environment-variables.html).

This is needed for non-standard set-ups that might not have guarantees about running in the current directory, and will stay exactly the same for the case that they are in the same directory.  I tried to be really defensive about it and make sure the current directory still works even if this environment variable is not set; However, it is guaranteed to be set by cargo so perhaps `.unwrap_or` is unnecessary in which case I could unwrap or expect it.

All tests passed with `cargo test`.  Happy to work with anyone to get this merged in!