### PR TITLE
Support filtering timezone names by regex

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,23 +30,14 @@ jobs:
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 \
             submodule update --init --force --recursive --depth=1
-
-    - name: clippy
-      if: ${{ matrix.run_lint }}
-      run: cargo clippy --color=always
-    - name: rustfmt
-      if: ${{ matrix.run_lint }}
-      run: cargo fmt -- --color=always --check
-
     - name: Run tests
       run: cargo test --color=always -- --color=always
+
     - name: Run tests serde
       run: cargo test --features serde --color=always -- --color=always
+
     - name: Run regex tests
-      working-directory: ./tests/check-regex-filtering
-      env:
-        CHRONO_TZ_BUILD_TIMEZONES: (Europe/London|GMT)
-      run: cargo test --color=always -- --color=always
+      run: bin/test-regex-filtering.sh
 
     - name: Check with no default features
       run: cargo check --no-default-features --color=always
@@ -70,3 +61,36 @@ jobs:
       run: |
         cargo clean
         cargo build --features serde1
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 \
+            submodule update --init --force --recursive --depth=1
+
+    - name: clippy
+      run: cargo clippy --color=always
+
+    - name: rustfmt
+      run: cargo fmt -- --color=always --check
+
+    # chrono-tz-build
+
+    - name: clippy chrono-tz-build
+      working-directory: ./chrono-tz-build
+      run: cargo clippy --color=always
+
+    - name: clippy chrono-tz-build filter-by-regex
+      working-directory: ./chrono-tz-build
+      run: cargo clippy --features filter-by-regex --color=always
+
+    - name: rustfmt
+      working-directory: ./chrono-tz-build
+      run: cargo fmt -- --color=always --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,12 @@ jobs:
       run: cargo test --color=always -- --color=always
     - name: Run tests serde
       run: cargo test --features serde --color=always -- --color=always
+    - name: Run regex tests
+      working-directory: ./tests/check-regex-filtering
+      env:
+        CHRONO_TZ_BUILD_TIMEZONES: (Europe/London|GMT)
+      run: cargo test --color=always -- --color=always
+
     - name: Check with no default features
       run: cargo check --no-default-features --color=always
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+Chrono-tz Changelog
+===================
+
+## 0.6.0
+
+* **tzdb** [breaking change] Update tzdb to 2020b, which removes the `US/Pacific-New` timezone.
+  https://github.com/eggert/tz/commit/284e877d7511d964249ecfd2e75a9cab85e2741a
+
+* **feature** Add support for filtering the set of timezones with a new `filter-by-regex` feature
+  which uses `CHRONO_TZ_TIMEZONE_FILTER` env var. It should be set to a regular expression of
+  timezones to include.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ std = []
 
 [build-dependencies]
 parse-zoneinfo = { version = "0.3" }
+regex = { default-features = false, version = "1"  }
 
 [dev-dependencies]
 serde_test = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ serde = { version = "1", optional = true, default-features = false }
 [features]
 default = ["std"]
 std = []
+filter-by-regex = ["chrono-tz-build/filter-by-regex"]
 
 [build-dependencies]
-parse-zoneinfo = { version = "0.3" }
-regex = { default-features = false, version = "1"  }
+chrono-tz-build = { path = "./chrono-tz-build", version = "0.0.1" }
 
 [dev-dependencies]
 serde_test = "1"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ lto = true
 Otherwise, the additional binary size added by this library may overflow
 available program space and trigger a linker error.
 
+## Limiting the Timezone Table to Zones of Interest
+
+`Chrono-tz` by default generates timezones for all entries in the
+[IANA database](http://www.iana.org/time-zones). If you are interested
+in only a few timezones you can use an environment variable to
+select them. The environment variable is called CHRONO_TZ_BUILD_TIMEZONES
+and is a regular expression. It should be specified in your top-level build:
+
+```sh
+CHRONO_TZ_BUILD_TIMEZONES="(Europe/London|US/.*)" cargo build
+```
+
+This can significantly reduce the size of the generated database, depending
+on how many timezones you are interested in. Wikipedia has an [article
+listing the timezone names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+The filtering applied is liberal; if you use a pattern such as "US/.*" then `chrono-tz` will
+include all the zones that are linked, such as 'America/Denver', not just 'US/Mountain'.
+
 ## Future Improvements
 
 - Handle leap seconds

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ assert_eq!(utc.to_string(), "2016-10-21 23:00:00 UTC");
 
 To use this library without depending on the Rust standard library, put this
 in your `Cargo.toml`:
+
 ```toml
 [dependencies]
 chrono = { version = "0.4", default-features = false }
@@ -162,22 +163,29 @@ available program space and trigger a linker error.
 
 ## Limiting the Timezone Table to Zones of Interest
 
-`Chrono-tz` by default generates timezones for all entries in the
-[IANA database](http://www.iana.org/time-zones). If you are interested
-in only a few timezones you can use an environment variable to
-select them. The environment variable is called CHRONO_TZ_BUILD_TIMEZONES
-and is a regular expression. It should be specified in your top-level build:
+`Chrono-tz` by default generates timezones for all entries in the [IANA database][]. If you are
+interested in only a few timezones you can use enable the `filter-by-regex` feature and set an
+environment variable to select them. The environment variable is called
+`CHRONO_TZ_TIMEZONE_FILTER` and is a regular expression. It should be specified in your top-level
+build:
 
-```sh
-CHRONO_TZ_BUILD_TIMEZONES="(Europe/London|US/.*)" cargo build
+```toml
+[dependencies]
+chrono-tz = { version = "0.6", features = [ "filter-by-regex" ] }
 ```
 
-This can significantly reduce the size of the generated database, depending
-on how many timezones you are interested in. Wikipedia has an [article
-listing the timezone names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+```sh
+CHRONO_TZ_TIMEZONE_FILTER="(Europe/London|US/.*)" cargo build
+```
+
+This can significantly reduce the size of the generated database, depending on how many timezones
+you are interested in. Wikipedia has an [article listing the timezone names][wiki-list].
 
 The filtering applied is liberal; if you use a pattern such as "US/.*" then `chrono-tz` will
-include all the zones that are linked, such as 'America/Denver', not just 'US/Mountain'.
+include all the zones that are linked, such as "America/Denver", not just "US/Mountain".
+
+[IANA database]: http://www.iana.org/time-zones
+[wiki-list]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 ## Future Improvements
 

--- a/bin/test-regex-filtering.sh
+++ b/bin/test-regex-filtering.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+export RUST_BACKTRACE=1
+export CHRONO_TZ_TIMEZONE_FILTER='(Europe/London|GMT)'
+
+cd tests/check-regex-filtering
+
+cargo test --color=always -- --color=always

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    chrono_tz_build::main();
+}

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "chrono-tz-build"
+version = "0.0.1"
+authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default-features = []
+filter-by-regex = ["regex"]
+
+[dependencies]
+parse-zoneinfo = { version = "0.3" }
+regex = { default-features = false, version = "1", optional = true }

--- a/tests/check-regex-filtering/Cargo.toml
+++ b/tests/check-regex-filtering/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-chrono-tz = { path = "../../", default-features = false }
+chrono-tz = { path = "../../", default-features = false, features = [ "filter-by-regex" ] }

--- a/tests/check-regex-filtering/Cargo.toml
+++ b/tests/check-regex-filtering/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "check-regex-filtering"
+version = "0.1.0"
+authors = ["Philip Daniels <Philip.Daniels1971@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+chrono = "0.4"
+chrono-tz = { path = "../../", default-features = false }

--- a/tests/check-regex-filtering/src/lib.rs
+++ b/tests/check-regex-filtering/src/lib.rs
@@ -1,0 +1,67 @@
+/// This test is compiled by the Github workflows with the
+/// filter regex set thusly: CHRONO_TZ_BUILD_TIMEZONES="(Europe/London|GMT)"
+///
+/// We use it to check two things:
+/// 1) That the compiled chrono-tz contains the correct timezones (a compilation
+///    failure will result if it doesn't).
+/// 2) That the compiled chrono-tz DOES NOT contain other, non-matched,
+///    timezones. This is rather trickier to do without triggering a compilation
+///    failure: we try our best by looking over the TZ_VARIANTS array to try and
+///    ascertain if it contains anything obviously wrong.
+
+#[cfg(test)]
+mod tests {
+    use chrono::offset::TimeZone;
+    use chrono_tz::{Europe, Europe::London, Tz, TZ_VARIANTS};
+    use std::str::FromStr;
+
+    #[test]
+    fn london_compiles() {
+        // This line will be a compilation failure if the code generation
+        // mistakenly excluded Europe::London.
+        let _london_time = London.ymd(2013, 12, 25).and_hms(14, 0, 0);
+        assert_eq!("Europe/London", London.name());
+
+        // Since London is included, converting from the corresponding
+        // string representation should also work.
+        assert_eq!(Tz::from_str("Europe/London"), Ok(London));
+
+        // We did not explicitly ask for Isle Of Man or Belfast in our regex, but there is a link
+        // from Europe::London to Isle_of_Man and Belfast (amongst others)
+        // so these conversions should also work.
+        assert_eq!(Tz::from_str("Europe/Isle_of_Man"), Ok(Europe::Isle_of_Man));
+        assert_eq!(Tz::from_str("Europe/Belfast"), Ok(Europe::Belfast));
+    }
+
+    #[test]
+    fn excluded_things_are_missing() {
+        // Timezones from outside Europe should not be included.
+        // We can't test all possible strings, here we just handle a
+        // representative set.
+        assert!(Tz::from_str("Australia/Melbourne").is_err());
+        assert!(Tz::from_str("Indian/Maldives").is_err());
+        assert!(Tz::from_str("Mexico/BajaSur").is_err());
+        assert!(Tz::from_str("Pacific/Kwajalein").is_err());
+        assert!(Tz::from_str("US/Central").is_err());
+
+        // The link table caused us to include some extra items from the UK (see
+        // `london_compiles()`), but it should NOT include various other timezones
+        // from around Europe since there is no linkage between them.
+        assert!(Tz::from_str("Europe/Brussels").is_err());
+        assert!(Tz::from_str("Europe/Dublin").is_err());
+        assert!(Tz::from_str("Europe/Warsaw").is_err());
+
+        // Also, entire continents outside Europe should be excluded.
+        for tz in TZ_VARIANTS.iter() {
+            assert!(!tz.name().starts_with("Africa"));
+            assert!(!tz.name().starts_with("Asia"));
+            assert!(!tz.name().starts_with("Australia"));
+            assert!(!tz.name().starts_with("Canada"));
+            assert!(!tz.name().starts_with("Chile"));
+            assert!(!tz.name().starts_with("Indian"));
+            assert!(!tz.name().starts_with("Mexico"));
+            assert!(!tz.name().starts_with("Pacific"));
+            assert!(!tz.name().starts_with("US"));
+        }
+    }
+}

--- a/tests/check-regex-filtering/src/lib.rs
+++ b/tests/check-regex-filtering/src/lib.rs
@@ -1,5 +1,5 @@
 /// This test is compiled by the Github workflows with the
-/// filter regex set thusly: CHRONO_TZ_BUILD_TIMEZONES="(Europe/London|GMT)"
+/// filter regex set thusly: CHRONO_TZ_TIMEZONE_FILTER="(Europe/London|GMT)"
 ///
 /// We use it to check two things:
 /// 1) That the compiled chrono-tz contains the correct timezones (a compilation


### PR DESCRIPTION
This adds the ability to only construct the tz enum variants based on a filtering Regex.

This is exactly #57 with a cleaned up history and a couple extra commits from me.