### PR TITLE
Release v0.6.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,12 +64,12 @@ jobs:
         cargo clean
         cargo build --features serde1
 
-    - name: Verify builds on no_std with uncased
+    - name: Verify builds on no_std case-insensitive
       if: ${{ matrix.run_no_std }}
       working-directory: ./tests/check-nostd
       run: |
         cargo clean
-        cargo build --features case_insensitive
+        cargo build --features case-insensitive
 
   lint:
     runs-on: ubuntu-latest
@@ -96,13 +96,9 @@ jobs:
       working-directory: ./chrono-tz-build
       run: cargo clippy --color=always
 
-    - name: clippy chrono-tz-build filter-by-regex
+    - name: clippy chrono-tz-build all features
       working-directory: ./chrono-tz-build
-      run: cargo clippy --features filter-by-regex --color=always
-
-    - name: clippy chrono-tz-build case_insensitive
-      working-directory: ./chrono-tz-build
-      run: cargo clippy --features case_insensitive --color=always
+      run: cargo clippy --all-features --color=always
 
     - name: rustfmt
       working-directory: ./chrono-tz-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@ Chrono-tz Changelog
 * **feature** Add support for filtering the set of timezones with a new `filter-by-regex` feature
   which uses `CHRONO_TZ_TIMEZONE_FILTER` env var. It should be set to a regular expression of
   timezones to include.
+
+* **feature** Add support for case-insensitive timezone matching via the `case-insensitive`
+  feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ uncased = { version = "0.9", optional = true, default-features = false }
 default = ["std"]
 std = []
 filter-by-regex = ["chrono-tz-build/filter-by-regex"]
-case_insensitive = ["uncased", "chrono-tz-build/case_insensitive"]
+case-insensitive = ["uncased", "chrono-tz-build/case-insensitive"]
 
 [build-dependencies]
 chrono-tz-build = { path = "./chrono-tz-build", version = "0.0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Djzin"]
 build = "build.rs"
 description = "TimeZone implementations for rust-chrono from the IANA database"
@@ -23,7 +23,7 @@ filter-by-regex = ["chrono-tz-build/filter-by-regex"]
 case-insensitive = ["uncased", "chrono-tz-build/case-insensitive"]
 
 [build-dependencies]
-chrono-tz-build = { path = "./chrono-tz-build", version = "0.0.1" }
+chrono-tz-build = { path = "./chrono-tz-build", version = "0.0.2" }
 
 [dev-dependencies]
 serde_test = "1"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chrono-TZ 0.5.3
+# Chrono-TZ 0.6
 
 `Chrono-TZ` is a library that provides implementors of the
 [`TimeZone`][timezone] trait for [`rust-chrono`][chrono]. The
@@ -23,7 +23,7 @@ Put this in your `Cargo.toml`:
 ```toml
 [dependencies]
 chrono = "0.4"
-chrono-tz = "0.5"
+chrono-tz = "0.6"
 ```
 
 Then you will need to write (in your crate root):

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz-build"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
 edition = "2018"
 description = "internal build script for chrono-tz"

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/chrono-tz-build"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 filter-by-regex = ["regex"]
-case_insensitive = ["uncased"]
+case-insensitive = ["uncased"]
 
 [dependencies]
 parse-zoneinfo = { version = "0.3" }

--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -100,7 +100,7 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()
     }
     writeln!(timezone_file, "static TIMEZONES: ::phf::Map<&'static str, Tz> = \n{};", map.build())?;
 
-    #[cfg(feature = "case_insensitive")]
+    #[cfg(feature = "case-insensitive")]
     {
         writeln!(timezone_file, "use uncased::UncasedStr;\n",)?;
         let mut map = phf_codegen::Map::new();
@@ -154,12 +154,12 @@ impl FromStr for Tz {{
     }}"
     )?;
 
-    #[cfg(feature = "case_insensitive")]
+    #[cfg(feature = "case-insensitive")]
     {
         writeln!(
             timezone_file,
             r#"
-    #[cfg(feature = "case_insensitive")]
+    #[cfg(feature = "case-insensitive")]
     /// Parses a timezone string in a case-insensitive way
     pub fn from_str_insensitive(s: &str) -> Result<Self, ParseError> {{
         #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ extern crate std as core;
 
 extern crate chrono;
 extern crate phf;
-#[cfg(feature = "case_insensitive")]
+#[cfg(feature = "case-insensitive")]
 extern crate uncased;
 
 #[cfg(feature = "serde")]

--- a/tests/check-nostd/Cargo.toml
+++ b/tests/check-nostd/Cargo.toml
@@ -12,4 +12,4 @@ chrono-tz = { path = "../../", default-features = false }
 
 [features]
 serde1 = ["chrono-tz/serde"]
-case_insensitive = ["chrono-tz/case_insensitive"]
+case-insensitive = ["chrono-tz/case-insensitive"]


### PR DESCRIPTION
This is breaking change because of a long-deprecated removal in the tz package,
it should be smooth sailing for most folks.

See CHANGELOG.md for details.