### PR TITLE
Fix update TZ to use main

### DIFF
--- a/.github/workflows/update-tz.yml
+++ b/.github/workflows/update-tz.yml
@@ -25,7 +25,7 @@ jobs:
           git fetch --tags --quiet origin
           orig_tag="$(git describe)"
 
-          git checkout master
+          git checkout main
           git pull --ff-only
 
           new_tag="$(git describe --abbrev=0)"


### PR DESCRIPTION
The `tz` repository now also uses `main` as the default branch.