### PR TITLE
bump version to 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz"
-version = "0.4.1"
+version = "0.5.3"
 authors = ["Djzin"]
 build = "build.rs"
 description = "TimeZone implementations for rust-chrono from the IANA database"


### PR DESCRIPTION
bumps version of `chrono-tz` to 0.5.3