### PR TITLE
Added `Tz::default()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 //! # }
 //! ```
 //!
-//! You can convert a timezone string to a timezone using the FromStr trait
+//! You can convert a timezone string to a timezone using the `FromStr` trait
 //!
 //! ```
 //! # extern crate chrono;
@@ -145,7 +145,7 @@
 //! # }
 //! ```
 //!
-//! If you need to iterate over all variants you can use the TZ_VARIANTS array
+//! If you need to iterate over all variants you can use the `TZ_VARIANTS` array
 //! ```
 //! use chrono_tz::{TZ_VARIANTS, Tz};
 //! assert!(TZ_VARIANTS.iter().any(|v| *v == Tz::UTC));

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -4,6 +4,7 @@ use chrono::{Duration, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, Offse
 use core::cmp::Ordering;
 use core::fmt::{Debug, Display, Error, Formatter};
 
+/// Returns [`Tz::UTC`].
 impl Default for Tz {
     fn default() -> Self {
        Tz::UTC

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -4,6 +4,12 @@ use chrono::{Duration, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, Offse
 use core::cmp::Ordering;
 use core::fmt::{Debug, Display, Error, Formatter};
 
+impl Default for Tz {
+    fn default() -> Self {
+       Tz::UTC
+    }
+}
+
 /// An Offset that applies for a period of time
 ///
 /// For example, [`::US::Eastern`] is composed of at least two


### PR DESCRIPTION
Rationale: allows deriving `Default` for a `struct` containing a `Tz` entity.

Returns `Tz::UTC`.