### PR TITLE
Make TIMEZONES map public, so that users may iterate over all timezones.

### DIFF
--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -100,7 +100,7 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()
     }
     writeln!(
         timezone_file,
-        "pub static TIMEZONES: ::phf::Map<&'static str, Tz> = \n{};",
+        "pub static TIME_ZONES: ::phf::Map<&'static str, Tz> = \n{};",
         map.build()
     )?;
 
@@ -113,7 +113,7 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()
         }
         writeln!(
             timezone_file,
-            "static TIMEZONES_UNCASED: ::phf::Map<&'static uncased::UncasedStr, Tz> = \n{};",
+            "static TIME_ZONES_UNCASED: ::phf::Map<&'static uncased::UncasedStr, Tz> = \n{};",
             // FIXME(petrosagg): remove this once rust-phf/rust-phf#232 is released
             map.build().to_string().replace("::std::mem::transmute", "::core::mem::transmute")
         )?;
@@ -130,9 +130,9 @@ impl FromStr for Tz {{
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {{
         #[cfg(feature = \"std\")]
-        return TIMEZONES.get(s).cloned().ok_or_else(|| format!(\"'{{}}' is not a valid timezone\", s));
+        return TIME_ZONES.get(s).cloned().ok_or_else(|| format!(\"'{{}}' is not a valid timezone\", s));
         #[cfg(not(feature = \"std\"))]
-        return TIMEZONES.get(s).cloned().ok_or(\"received invalid timezone\");
+        return TIME_ZONES.get(s).cloned().ok_or(\"received invalid timezone\");
     }}
 }}\n"
     )?;
@@ -167,9 +167,9 @@ impl FromStr for Tz {{
     /// Parses a timezone string in a case-insensitive way
     pub fn from_str_insensitive(s: &str) -> Result<Self, ParseError> {{
         #[cfg(feature = "std")]
-        return TIMEZONES_UNCASED.get(s.into()).cloned().ok_or_else(|| format!("'{{}}' is not a valid timezone", s));
+        return TIME_ZONES_UNCASED.get(s.into()).cloned().ok_or_else(|| format!("'{{}}' is not a valid timezone", s));
         #[cfg(not(feature = "std"))]
-        return TIMEZONES_UNCASED.get(s.into()).cloned().ok_or("received invalid timezone");
+        return TIME_ZONES_UNCASED.get(s.into()).cloned().ok_or("received invalid timezone");
     }}"#
         )?;
     }

--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -98,7 +98,11 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()
     for zone in &zones {
         map.entry(zone, &format!("Tz::{}", convert_bad_chars(zone)));
     }
-    writeln!(timezone_file, "static TIMEZONES: ::phf::Map<&'static str, Tz> = \n{};", map.build())?;
+    writeln!(
+        timezone_file,
+        "pub static TIMEZONES: ::phf::Map<&'static str, Tz> = \n{};",
+        map.build()
+    )?;
 
     #[cfg(feature = "case-insensitive")]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@ pub use directory::*;
 pub use timezone_impl::{OffsetComponents, OffsetName};
 pub use timezones::ParseError;
 pub use timezones::Tz;
+pub use timezones::TIMEZONES;
 pub use timezones::TZ_VARIANTS;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub use directory::*;
 pub use timezone_impl::{OffsetComponents, OffsetName};
 pub use timezones::ParseError;
 pub use timezones::Tz;
-pub use timezones::TIMEZONES;
+pub use timezones::TIME_ZONES;
 pub use timezones::TZ_VARIANTS;
 
 #[cfg(test)]


### PR DESCRIPTION
I could imagine, that this PR is not implemented in the way you'd prefer. I mostly want to get the conversation started and offer one possible implementation.

For [a feature](https://github.com/aquanauts/rizzy/issues/9), I thought it would be nice to create an auto-correct dictionary for all known timezones. 

So, in this PR I am changing `static TIMEZONES` to `pub static TIMEZONES`. On the user side, I am simply creating a list off all timezones like this: `chrono_tz::TIMEZONES.keys().map(|x| x.to_string()).collect()`.

Is this something you would be willing to support? Would you prefer a new function that hid the access to TIMEZONES behind a function?

---

Pinging previous authors of the modified file: @quodlibetor @petrosagg 