### PR TITLE
chrono-tz-build: prepare v0.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ filter-by-regex = ["chrono-tz-build/filter-by-regex"]
 case-insensitive = ["uncased", "chrono-tz-build/case-insensitive"]
 
 [build-dependencies]
-chrono-tz-build = { path = "./chrono-tz-build", version = "0.0.2" }
+chrono-tz-build = { path = "./chrono-tz-build", version = "0.0.3" }
 
 [dev-dependencies]
 serde_test = "1"

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz-build"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Brandon W Maister <quodlibetor@gmail.com>"]
 edition = "2018"
 description = "internal build script for chrono-tz"


### PR DESCRIPTION
@djc I realized after I tried upgrading to v0.6.2 that we need a new release of chrono-tz-build too!

----

This release corresponds to chrono-tz v0.6.2 and bumps the dependency on
the phf family of crates to v0.11.0.