### PR TITLE
Only enable `uncased` feature in `phf` if `case-insensitive` feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ license = "MIT/Apache-2.0"
 [dependencies]
 chrono = { version = "0.4", default-features = false }
 serde = { version = "1", optional = true, default-features = false }
-phf = { version = "0.11", default-features = false, features = ["uncased"] }
+phf = { version = "0.11", default-features = false }
 uncased = { version = "0.9", optional = true, default-features = false }
 
 [features]
 default = ["std"]
 std = []
 filter-by-regex = ["chrono-tz-build/filter-by-regex"]
-case-insensitive = ["uncased", "chrono-tz-build/case-insensitive"]
+case-insensitive = ["uncased", "chrono-tz-build/case-insensitive", "phf/uncased"]
 
 [build-dependencies]
 chrono-tz-build = { path = "./chrono-tz-build", version = "0.0.3" }

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/chrono-tz-build"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 filter-by-regex = ["regex"]
-case-insensitive = ["uncased"]
+case-insensitive = ["uncased", "phf/uncased"]
 
 [dependencies]
 parse-zoneinfo = { version = "0.3" }
 regex = { default-features = false, version = "1", optional = true }
-phf = { version = "0.11", default-features = false, features = ["uncased"] }
+phf = { version = "0.11", default-features = false }
 phf_codegen = { version = "0.11", default-features = false }
 uncased = { version = "0.9", optional = true, default-features = false }


### PR DESCRIPTION
See also:

- #104