### PR TITLE
Export TzOffset

### DIFF
--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -140,7 +140,7 @@ mod timezone_impl;
 mod timezones;
 
 pub use crate::directory::*;
-pub use crate::timezone_impl::{OffsetComponents, OffsetName};
+pub use crate::timezone_impl::{OffsetComponents, OffsetName, TzOffset};
 pub use crate::timezones::ParseError;
 pub use crate::timezones::Tz;
 pub use crate::timezones::TZ_VARIANTS;


### PR DESCRIPTION
This type is included in the `Tz`'s implementation of `TimeZone` and not exporting it makes it difficult to work with `Tz` in wrapper types. Are there changes planned for this type that preclude it from being exported or is this okay?