### PR TITLE
Derive Arbitrary for Tz

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ include all the zones that are linked, such as "America/Denver", not just "US/Mo
 [IANA database]: http://www.iana.org/time-zones
 [wiki-list]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
+## Developing
+
+`chrono-tz` uses git submodules, so in order to build locally you will need to
+run `git submodule init` and `git submodule update`.
+
 ## Future Improvements
 
 - Handle leap seconds

--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -82,7 +82,9 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()
 /// construct chrono's DateTime type. See the root module documentation
 /// for details."
     )?;
-    writeln!(timezone_file, "#[derive(Clone, Copy, PartialEq, Eq, Hash)]\npub enum Tz {{")?;
+    writeln!(timezone_file, "#[derive(Clone, Copy, PartialEq, Eq, Hash)]")?;
+    writeln!(timezone_file, r#"#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]"#)?;
+    writeln!(timezone_file, "pub enum Tz {{")?;
     for zone in &zones {
         let zone_name = convert_bad_chars(zone);
         writeln!(

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+arbitrary = { version = "1.2", optional = true, features = ["derive"] }
 chrono = { version = "0.4", default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 phf = { version = "0.11", default-features = false }


### PR DESCRIPTION
This allows downstream users to `#[derive(Arbitrary)]` for types that contain a `chrono_tz::Tz`.

Unfortunately, it seems like I'm missing some files to actually run `cargo test` even before my changes and the readme doesn't tell me where to find them, so I'll hope CI is able to run tests for me. Also I guess it means I won't be able to depend on a git-version of chrono-tz while waiting for this to make it into a release if it's accepted, so I'd be happy to hear if you know where I can find the files :)

Also BTW, would you be interested in also having `bolero_generator::TypeGenerator` be derived for chrono types? I'm PRing Arbitrary here because it's already supported by chrono, but am actually looking into using it from bolero, so I'd be happy to PR optional derives for bolero generator for both chrono and chrono-tz types, as it'd probably work better than trying to use Arbitrary from a bolero generator :)