### PR TITLE
Bump to version 0.8.2 and 2023c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Chrono-tz Changelog
 ===================
 
+## 0.8.3
+
+* **tzdb** Update tzdb from 2023b to 2023c. All changes in 2023b have been
+    reverted back to 2023a. The full list of changes can be found
+    [here](https://mm.icann.org/pipermail/tz-announce/2023-March/000079.html)
+
 ## 0.8.2
 
 * **tzdb** Update tzdb from 2022f to 2023b. Some timezones have been linked. For

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,9 @@ Chrono-tz Changelog
 
 ## 0.8.3
 
-* **tzdb** Update tzdb from 2023b to 2023c. All changes in 2023b have been
+* **tzdb** Update tzdb from 2022f to 2023c. All changes in 2023b have been
     reverted back to 2023a. The full list of changes can be found
     [here](https://mm.icann.org/pipermail/tz-announce/2023-March/000079.html)
-
-## 0.8.2
-
-* **tzdb** Update tzdb from 2022f to 2023b. Some timezones have been linked. For
-  the full list, check the
-  [2023a](https://mm.icann.org/pipermail/tz-announce/2023-March/000077.html) and
-  [2023b](https://mm.icann.org/pipermail/tz-announce/2023-March/000078.html) announcements.
 
 ## 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Chrono-tz Changelog
 ===================
 
-## 0.8.3
+## 0.8.2
 
 * **tzdb** Update tzdb from 2022f to 2023c. All changes in 2023b have been
     reverted back to 2023a. The full list of changes can be found

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz"
-version = "0.8.3"
+version = "0.8.2"
 build = "build.rs"
 description = "TimeZone implementations for chrono from the IANA database"
 keywords = ["date", "time", "timezone", "zone", "calendar"]

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz"
-version = "0.8.2"
+version = "0.8.3"
 build = "build.rs"
 description = "TimeZone implementations for chrono from the IANA database"
 keywords = ["date", "time", "timezone", "zone", "calendar"]

--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -155,7 +155,6 @@ pub use timezones::TZ_VARIANTS;
 #[cfg(test)]
 mod tests {
     use super::America::Danmarkshavn;
-    use super::Asia::Beirut;
     use super::Asia::Dhaka;
     use super::Australia::Adelaide;
     use super::Europe::Berlin;
@@ -231,18 +230,6 @@ mod tests {
         let later = dt + Duration::days(180);
         let expected = London.ymd(2016, 9, 6).and_hms(6, 0, 0);
         assert_eq!(later, expected);
-    }
-
-    #[test]
-    fn lebanon_dst_2023b() {
-        let dt = Beirut.ymd(2023, 3, 24).and_hms(5, 0, 0);
-        let later_norm = dt + Duration::days(3);
-        let expected_norm = Beirut.ymd(2023, 3, 27).and_hms(5, 0, 0);
-        assert_eq!(later_norm, expected_norm);
-
-        let later_dst = dt + Duration::days(30);
-        let expected_dst = Beirut.ymd(2023, 4, 23).and_hms(6, 0, 0);
-        assert_eq!(later_dst, expected_dst);
     }
 
     #[test]


### PR DESCRIPTION
- Update to tzdb to 2023c
- Bump chrono-tz to 0.8.2