### PR TITLE
chore: Make features more explict

### DIFF
--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -21,8 +21,9 @@ uncased = { version = "0.9", optional = true, default-features = false }
 [features]
 default = ["std"]
 std = []
+serde = ["dep:serde"]
 filter-by-regex = ["chrono-tz-build/filter-by-regex"]
-case-insensitive = ["uncased", "chrono-tz-build/case-insensitive", "phf/uncased"]
+case-insensitive = ["dep:uncased", "chrono-tz-build/case-insensitive", "phf/uncased"]
 
 [build-dependencies]
 chrono-tz-build = { path = "../chrono-tz-build", version = "0.2" }


### PR DESCRIPTION
This PR will use `dep:xxx` to make available features more explict. Before this change, it's hard to find that `chrono-tz` has a `serde` feature.