### PR TITLE
Support for `schemars` crate

### DIFF
--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -17,13 +17,19 @@ chrono = { version = "0.4.24", default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 phf = { version = "0.11", default-features = false }
 uncased = { version = "0.9", optional = true, default-features = false }
+schemars = { version = "0.8.16", optional = true, default-features = false }
 
 [features]
 default = ["std"]
 std = []
 serde = ["dep:serde"]
 filter-by-regex = ["chrono-tz-build/filter-by-regex"]
-case-insensitive = ["dep:uncased", "chrono-tz-build/case-insensitive", "phf/uncased"]
+case-insensitive = [
+    "dep:uncased",
+    "chrono-tz-build/case-insensitive",
+    "phf/uncased",
+]
+schemars = ["dep:schemars"]
 
 [build-dependencies]
 chrono-tz-build = { path = "../chrono-tz-build", version = "0.2.1" }
@@ -31,6 +37,10 @@ chrono-tz-build = { path = "../chrono-tz-build", version = "0.2.1" }
 [dev-dependencies]
 serde_test = "1"
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.25", default-features = false, features = [
+    "alloc",
+] }
+jsonschema = { version = "0.17.1", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -134,6 +134,9 @@
 #[cfg(feature = "serde")]
 mod serde;
 
+#[cfg(feature = "schemars")]
+mod schemars;
+
 mod binary_search;
 mod directory;
 mod timezone_impl;

--- a/chrono-tz/src/schemars.rs
+++ b/chrono-tz/src/schemars.rs
@@ -1,0 +1,39 @@
+use crate::{Tz, TZ_VARIANTS};
+
+impl schemars::JsonSchema for Tz {
+    fn schema_name() -> String {
+        "Tz".into()
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            instance_type: Some(schemars::schema::InstanceType::String.into()),
+            enum_values: Some(TZ_VARIANTS.iter().map(|variant| variant.name().into()).collect()),
+            ..Default::default()
+        })
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Tz;
+
+    #[test]
+    fn json_schema() {
+        let schema = jsonschema::JSONSchema::compile(
+            &serde_json::to_value(schemars::schema_for!(Tz)).unwrap(),
+        )
+        .expect("a valid schema");
+
+        assert!(schema.is_valid(&serde_json::Value::from("Europe/London")));
+        assert!(schema.is_valid(&serde_json::Value::from("Africa/Abidjan")));
+        assert!(schema.is_valid(&serde_json::Value::from("UTC")));
+        assert!(schema.is_valid(&serde_json::Value::from("Zulu")));
+
+        assert!(!schema.is_valid(&serde_json::Value::from("MadeUpInvalidTimezone")));
+    }
+}


### PR DESCRIPTION
This adds, behind a feature flag, support for `schemars` crate, which allows generating JSON schemas from Rust code.