### PR TITLE
Reduce packaged crate files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,11 @@ jobs:
         cargo clean
         cargo build --features case-insensitive
 
+    - name: Verify cargo publish includes all files needed to build
+      run: |
+        cargo package --list -p chrono-tz
+        cargo publish --dry-run -p chrono-tz
+
   lint:
     runs-on: ubuntu-latest
 

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -10,6 +10,22 @@ repository = "https://github.com/chronotope/chrono-tz"
 documentation = "https://docs.rs/chrono-tz"
 readme = "../README.md"
 license = "MIT OR Apache-2.0"
+include = [
+  "src/*.rs",
+  "tests/*.rs",
+  "build.rs",
+  "LICENSE",
+  "tz/africa",
+  "tz/antarctica",
+  "tz/asia",
+  "tz/australasia",
+  "tz/backward",
+  "tz/etcetera",
+  "tz/europe",
+  "tz/northamerica",
+  "tz/southamerica",
+  "tz/NEWS",
+]
 
 [dependencies]
 arbitrary = { version = "1.2", optional = true, features = ["derive"] }


### PR DESCRIPTION
There is no need to include all the scripts, C code and auxilary information of the time zone database in the package of Chrono-TZ.

I added an `inlude`-list in `cargo.toml`, and a CI run to test we included all files necessary to build.
This reduces the size of our crates.io package from 622 kB to 366 kB.