### PR TITLE
Don't set `no_std` for tests

### DIFF
--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -128,7 +128,7 @@
 //! assert!(TZ_VARIANTS.iter().any(|v| *v == Tz::UTC));
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This allows running the tests with `--no-default-features`. Chrono-TZ will stille only have the `no_std` functionality, but we can use the standard library in tests.

Alternative to the closed by author #123.