### PR TITLE
Make `ParseError` a real `Error` enum

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,8 +73,19 @@ jobs:
 
     - name: Verify cargo publish includes all files needed to build
       run: |
-        cargo package --list -p chrono-tz
-        cargo publish --dry-run -p chrono-tz
+        cargo vendor
+        cargo package -p chrono-tz-build
+        cargo package -p chrono-tz --no-verify
+        for crate in target/package/*.crate
+        do
+          name=$(basename "$crate" .crate)
+          tar xvfz "$crate" -C vendor/
+          # Crates in the vendor directory require a checksum file, but it
+          # doesn't matter if it is empty.
+          echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
+        done
+        cargo package --config "source.vendored-sources.directory = 'vendor'" \
+           --config "source.crates-io.replace-with = 'vendored-sources'"
 
   lint:
     runs-on: ubuntu-latest

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.60"
 description = "internal build script for chrono-tz"

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.60"
 build = "build.rs"
@@ -43,7 +43,7 @@ filter-by-regex = ["chrono-tz-build/filter-by-regex"]
 case-insensitive = ["dep:uncased", "chrono-tz-build/case-insensitive", "phf/uncased"]
 
 [build-dependencies]
-chrono-tz-build = { path = "../chrono-tz-build", version = "0.2.1" }
+chrono-tz-build = { path = "../chrono-tz-build", version = "0.3" }
 
 [dev-dependencies]
 serde_test = "1"


### PR DESCRIPTION
To continue #122 by @laralove143.

I added a second error type that is used when deserializing, which can borrow the input string and print a nice message (without needing to allocate).

Fixes @121.