### PR TITLE
Never strip `GMT` and `UTC` time zones

### DIFF
--- a/bin/test-regex-filtering.sh
+++ b/bin/test-regex-filtering.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 export RUST_BACKTRACE=1
-export CHRONO_TZ_TIMEZONE_FILTER='(Europe/London|GMT|UTC)'
+export CHRONO_TZ_TIMEZONE_FILTER='(Europe/London)'
 
 cd chrono-tz/tests/check-regex-filtering
 

--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -328,6 +328,8 @@ mod filter {
 }
 
 /// Module containing code supporting filter-by-regex feature
+///
+/// The "GMT" and "UTC" time zones are always included.
 #[cfg(feature = "filter-by-regex")]
 mod filter {
     use std::collections::HashSet;
@@ -390,13 +392,13 @@ mod filter {
     fn filter_timezone_table(table: &mut Table, filter_regex: Regex) {
         // Compute the transitive closure of things to keep.
         // Doing this, instead of just filtering `zonesets` and `links` by the
-        // regiex, helps to keep the `structure()` intact.
+        // regex, helps to keep the `structure()` intact.
         let mut keep = HashSet::new();
         for (k, v) in &table.links {
-            if filter_regex.is_match(k) {
+            if filter_regex.is_match(k) || k == "GMT" || k == "UTC" {
                 insert_keep_entry(&mut keep, k);
             }
-            if filter_regex.is_match(v) {
+            if filter_regex.is_match(v) || k == "GMT" || k == "UTC" {
                 insert_keep_entry(&mut keep, v);
             }
         }


### PR DESCRIPTION
The UTC time zone is needed for `TZ::default()`. And those two zones are generally expected to always exist.

Fixes #148.