### PR TITLE
Optimize size of `TzOffset`

### DIFF
--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -112,8 +112,7 @@ fn write_timezone_file(timezone_file: &mut File, table: &Table) -> io::Result<()
         writeln!(
             timezone_file,
             "static TIMEZONES_UNCASED: ::phf::Map<&'static uncased::UncasedStr, Tz> = \n{};",
-            // FIXME(petrosagg): remove this once rust-phf/rust-phf#232 is released
-            map.build().to_string().replace("::std::mem::transmute", "::core::mem::transmute")
+            map.build()
         )?;
     }
 

--- a/chrono-tz/src/directory.rs
+++ b/chrono-tz/src/directory.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-#![allow(dead_code)]
 include!(concat!(env!("OUT_DIR"), "/directory.rs"));

--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_type_size() {
-        assert_eq!(core::mem::size_of::<TzOffset>(), 16);
-        assert_eq!(core::mem::size_of::<DateTime<Tz>>(), 28);
+        assert_eq!(core::mem::size_of::<TzOffset>(), 12);
+        assert_eq!(core::mem::size_of::<DateTime<Tz>>(), 24);
     }
 }

--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -163,7 +163,8 @@ mod tests {
     use super::IANA_TZDB_VERSION;
     use super::US::Eastern;
     use super::UTC;
-    use chrono::{Duration, NaiveDate, TimeZone};
+    use crate::TzOffset;
+    use chrono::{DateTime, Duration, NaiveDate, TimeZone};
 
     #[test]
     fn london_to_berlin() {
@@ -411,5 +412,11 @@ mod tests {
         let numbers: Vec<&str> = IANA_TZDB_VERSION.matches(char::is_numeric).collect();
         assert_eq!(4, numbers.len());
         assert!(IANA_TZDB_VERSION.ends_with(|c: char| c.is_ascii_lowercase()));
+    }
+
+    #[test]
+    fn test_type_size() {
+        assert_eq!(core::mem::size_of::<TzOffset>(), 32);
+        assert_eq!(core::mem::size_of::<DateTime<Tz>>(), 48);
     }
 }

--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_type_size() {
-        assert_eq!(core::mem::size_of::<TzOffset>(), 32);
-        assert_eq!(core::mem::size_of::<DateTime<Tz>>(), 48);
+        assert_eq!(core::mem::size_of::<TzOffset>(), 16);
+        assert_eq!(core::mem::size_of::<DateTime<Tz>>(), 28);
     }
 }

--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_type_size() {
-        assert_eq!(core::mem::size_of::<TzOffset>(), 12);
-        assert_eq!(core::mem::size_of::<DateTime<Tz>>(), 24);
+        assert_eq!(core::mem::size_of::<TzOffset>(), 8);
+        assert_eq!(core::mem::size_of::<DateTime<Tz>>(), 20);
     }
 }


### PR DESCRIPTION
Three changes that bring the size of `DateTime<Tz>` down from 48 bytes to 20 bytes:
- The build script collects all abbreviations and concatenates them into one string. We compactly store an index and length into this string in one `i16`. All abbreviations are at most 6 characters and the entire string is ca. 650 characters. So it fits easily.
- The base offset from UTC doesn't fit into an `i16`, it needs 17 bits. We give it 18 bits of an `i32`. The DST offset from the base offset is much smaller, it can fit into the remaining 14 bits. This spares one `i32`.
- There are 2 bytes of padding in the `FixedTimespan` type, and 2 bytes of padding in the `TzOffset` type. If we don't wrap the `FixedTimespan` but copy its two fields into `TzOffset` we get rid of the padding, which is 33% of the type.

A binary compiled with these size optimizations is 1,5Mb smaller :tada:.

Fixes https://github.com/chronotope/chrono-tz/issues/27.
