### PR TITLE
Use regex-lite for chrono-tz-build

### DIFF
--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -14,11 +14,11 @@ documentation = "https://docs.rs/chrono-tz-build"
 [features]
 filter-by-regex = ["regex"]
 case-insensitive = ["uncased", "phf/uncased"]
-regex = ["dep:regex"]
+regex = ["dep:regex-lite"]
 
 [dependencies]
 parse-zoneinfo = { version = "0.3" }
-regex = { default-features = false, version = "1", optional = true }
+regex-lite = { version = "0.1", optional = true }
 phf = { version = "0.11", default-features = false }
 phf_codegen = { version = "0.11", default-features = false }
 uncased = { version = "0.9", optional = true, default-features = false }

--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate parse_zoneinfo;
-#[cfg(feature = "filter-by-regex")]
-extern crate regex;
-
 use std::collections::BTreeSet;
 use std::env;
 use std::fs::File;
@@ -382,7 +378,7 @@ mod filter {
     use std::collections::HashSet;
     use std::env;
 
-    use regex::Regex;
+    use regex_lite::Regex;
 
     use crate::{Table, FILTER_ENV_VAR_NAME};
 


### PR DESCRIPTION
We don't need a featureful or high-performance parser for the build script.