### PR TITLE
Remove `AsciiExt` import

### DIFF
--- a/parse-zoneinfo/src/line.rs
+++ b/parse-zoneinfo/src/line.rs
@@ -70,9 +70,6 @@
 
 use std::fmt;
 use std::str::FromStr;
-// we still support rust that doesn't have the inherent methods
-#[allow(deprecated, unused_imports)]
-use std::ascii::AsciiExt;
 
 use regex::{Captures, Regex};
 


### PR DESCRIPTION
The commit message of https://github.com/chronotope/chrono-tz/commit/dc6aa7d15ef7633f7cc234b9ea50808999ce92dd says:

> When we update to depend on rust 1.26 we can remove this silencing.