### PR TITLE
Prepare parse-zoneinfo v0.3.1

### DIFF
--- a/parse-zoneinfo/Cargo.toml
+++ b/parse-zoneinfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parse-zoneinfo"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.56.0"
 description = "Parse zoneinfo files from the IANA database"


### PR DESCRIPTION
De we want to do a new release of parse-zoneinfo?
Is is mostly doc improvements, and the comment parsing fix that will allow us to remove a [workaround from chrono-tz-build](https://github.com/chronotope/chrono-tz/blob/v0.9.0/chrono-tz-build/src/lib.rs#L24).

https://github.com/chronotope/chrono-tz/pull/176 is needed to package a `LICENSE` file, and https://github.com/chronotope/chrono-tz/pull/174 may be nice as well.