### PR TITLE
Bump chrono-tz-build to 0.4.0

### DIFF
--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono-tz-build"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.60"
 description = "internal build script for chrono-tz"

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -43,7 +43,7 @@ filter-by-regex = ["chrono-tz-build/filter-by-regex"]
 case-insensitive = ["dep:uncased", "chrono-tz-build/case-insensitive", "phf/uncased"]
 
 [build-dependencies]
-chrono-tz-build = { path = "../chrono-tz-build", version = "0.3" }
+chrono-tz-build = { path = "../chrono-tz-build", version = "0.4" }
 
 [dev-dependencies]
 serde_test = "1"


### PR DESCRIPTION
I forgot we need to release a new version of chrono-tz-build first.