### PR TITLE
Fix verify publish ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,9 @@ jobs:
           # doesn't matter if it is empty.
           echo '{"files":{}}' > vendor/$name/.cargo-checksum.json
         done
-        cargo package --config "source.vendored-sources.directory = 'vendor'" \
+        cargo package -p chrono-tz --config "source.vendored-sources.directory = 'vendor'" \
+           --config "source.crates-io.replace-with = 'vendored-sources'"
+        cargo package -p chrono-tz-build --config "source.vendored-sources.directory = 'vendor'" \
            --config "source.crates-io.replace-with = 'vendored-sources'"
 
   lint:


### PR DESCRIPTION
Step `Verify cargo publish includes all files needed to build` is failing with:
```
error: crates-io is replaced with non-remote-registry source dir chrono-tz/vendor;
include `--registry crates-io` to use crates.io
```

The error appears only with cargo 1.82 and greater.

Passing `--registry crates-io` is not a solution because it a nightly-only option.

Calling `cargo publish -p <name>` for each crate solves the problem.