### PR TITLE
Fix chrono-tz-build dep on parse-zoneinfo

### DIFF
--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -17,7 +17,7 @@ case-insensitive = ["uncased", "phf_shared/uncased"]
 regex = ["dep:regex"]
 
 [dependencies]
-parse-zoneinfo = { version = "0.3" }
+parse-zoneinfo = { version = "0.3.1" }
 regex = { default-features = false, version = "1", optional = true }
 phf_codegen = { version = "0.11", default-features = false }
 uncased = { version = "0.9", optional = true, default-features = false }


### PR DESCRIPTION
`chrono-tz-build` had a dependency on `parse-zoneinfo = "0.3"`, which is not enough, it needs at least 0.3.1:

```console
$ cat Cargo.toml
[package]
name = "ttt"
version = "0.1.0"
edition = "2024"

[dependencies]
chrono-tz-build = "0.4.1"
parse-zoneinfo = "=0.3.0"

$ cargo c
    Checking chrono-tz-build v0.4.1
error[E0599]: no function or associated item named `default` found for struct `LineParser` in the current scope
   --> /home/goldstein/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/chrono-tz-build-0.4.1/src/lib.rs:517:30
    |
517 |     let parser = LineParser::default();
    |                              ^^^^^^^ function or associated item not found in `LineParser`
    |
note: if you're trying to build a new `LineParser`, consider using `LineParser::new` which returns `LineParser`
   --> /home/goldstein/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parse-zoneinfo-0.3.0/src/line.rs:36:5
    |
36  |     pub fn new() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `chrono-tz-build` (lib) due to 1 previous error
```
