### PR TITLE
Fix unresolved crate `uncased` when enabling `case-insensitive` feature

### DIFF
--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -131,6 +131,9 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+#[cfg(feature = "case-insensitive")]
+extern crate uncased;
+
 #[cfg(feature = "serde")]
 mod serde;
 


### PR DESCRIPTION
### What this PR does
This PR fixes a build error when using the `case-insensitive` feature:
```rust
error[E0432]: unresolved import `uncased`
    --> .../target/debug/build/chrono-tz-6ad4e777f9f8ab89/out/timezones.rs:1934:5
     |
1934 | use uncased::UncasedStr;
     |     ^^^^^^^ use of unresolved module or unlinked crate `uncased`
     |
     = help: if you wanted to use a crate named `uncased`, use `cargo add uncased` to add it to your `Cargo.toml`
     
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `uncased`
    --> .../target/debug/build/chrono-tz-6ad4e777f9f8ab89/out/timezones.rs:1936:47
     |
1936 | static TIMEZONES_UNCASED: ::phf::Map<&'static uncased::UncasedStr, Tz> =
     |                                               ^^^^^^^ use of unresolved module or unlinked crate `uncased`
     |
     = help: if you wanted to use a crate named `uncased`, use `cargo add uncased` to add it to your `Cargo.toml`
```     
This happens because the `uncased` crate is only used in the code generated by `chrono-tz/build.rs`, and not referenced directly in the source code. As a result, the Rust compiler/linker doesn't retain the dependency.

### Why this fix?
- This is a minimal and idiomatic solution for generated code relying on external crates.
- It avoids modifying the generated `timezones.rs` file.
- It aligns with best practices for #[cfg]-based conditional dependency linking.

### Related info
I encountered this error when trying to use it in dbt-fusion ([PR-145](https://github.com/dbt-labs/dbt-fusion/pull/145)) building with:

```toml
chrono-tz = { version = "0.10.1", features = ["case-insensitive"] }
```