### PR TITLE
Bump MSRV to 1.66

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -136,5 +136,5 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.65.0
+          toolchain: 1.66.0
       - run: cargo check --lib

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chrono-tz-build"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.66"
 description = "internal build script for chrono-tz"
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chrono-tz"
 version = "0.11.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.66"
 build = "build.rs"
 description = "TimeZone implementations for chrono from the IANA database"
 keywords = ["date", "time", "timezone", "zone", "iana"]

--- a/parse-zoneinfo/Cargo.toml
+++ b/parse-zoneinfo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "parse-zoneinfo"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.66"
 description = "Parse zoneinfo files from the IANA database"
 repository = "https://github.com/chronotope/chrono-tz"
 readme = "README.md"

--- a/parse-zoneinfo/README.md
+++ b/parse-zoneinfo/README.md
@@ -28,10 +28,6 @@ Parse-zoneinfo is a fork of [`zoneinfo_parse`] by Benjamin Sago (now unmaintaine
 [`zoneinfo_parse`]: https://crates.io/crates/zoneinfo_parse
 [`chrono-tz`]: https://crates.io/crates/chrono-tz
 
-## Rust version requirements
-
-The Minimum Supported Rust Version (MSRV) is currently **Rust 1.57.0**.
-
 # Usage
 
 The zoneinfo files contains `Zone`, `Rule`, and `Link` information. Each type of line forms a variant in the `line::Line` enum.


### PR DESCRIPTION
Allows updating `phf` to 0.13

https://github.com/chronotope/chrono-tz/pull/223#issuecomment-3338315955