### PR TITLE
Add range filter to chrono-tz-build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run regex tests
         run: bin/test-regex-filtering.sh
 
+      - name: Run range tests
+        run: bash bin/test-range-filtering.sh
+
       - name: Check with no default features
         run: cargo check --no-default-features --color=always
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,6 +89,15 @@ jobs:
           cargo package -p chrono-tz --config "source.vendored-sources.directory = 'vendor'" \
              --config "source.crates-io.replace-with = 'vendored-sources'"
 
+      # chrono-tz-build
+      - name: Test chrono-tz-build
+        if: ${{ matrix.run_lint }}
+        run: cargo test -p chrono-tz-build --color=always -- --color=always
+
+      - name: Test chrono-tz-build all features
+        if: ${{ matrix.run_lint }}
+        run: cargo test -p chrono-tz-build --all-features --color=always -- --color=always
+
   lint:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ CHRONO_TZ_TIMEZONE_FILTER="(Europe/London|US/.*)" cargo build
 This can significantly reduce the size of the generated database, depending on how many timezones
 you are interested in. Wikipedia has an [article listing the timezone names][wiki-list].
 
-The filtering applied is liberal; if you use a pattern such as "US/.*" then `chrono-tz` will include all the zones that are linked, such as "America/Denver", not just "US/Mountain".
+The filtering applied is liberal; if you use a pattern such as "US/.*" then `chrono-tz` will
+include all the zones that are linked, such as "America/Denver", not just "US/Mountain".
 
 ### Limiting the Table to a Timestamp Range
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ chrono-tz = { version = "0.5", default-features = false }
 If you are using this library in an environment with limited program
 space, such as a microcontroller, take note that you will also likely
 need to enable optimizations and Link Time Optimization:
+
 ```toml
 [profile.dev]
 opt-level = 2
@@ -177,7 +178,7 @@ CHRONO_TZ_TIMEZONE_FILTER="(Europe/London|US/.*)" cargo build
 This can significantly reduce the size of the generated database, depending on how many timezones
 you are interested in. Wikipedia has an [article listing the timezone names][wiki-list].
 
-The filtering applied is liberal; if you use a pattern such as "US/.*" then `chrono-tz` will
+The filtering applied is liberal; if you use a pattern such as "US/.\*" then `chrono-tz` will
 include all the zones that are linked, such as "America/Denver", not just "US/Mountain".
 
 ### Limiting the Table to a Timestamp Range
@@ -186,7 +187,7 @@ If you only care about timezone behavior within a bounded period, enable `filter
 `CHRONO_TZ_TIME_RANGE` to a Rust-style timestamp range in Unix seconds:
 
 ```sh
-# Only keep data from 2020-01-01 to 2030-01-01 UTC
+# Only keep data from 2020-01-01 to 2030-01-01 UTC (Exclusive)
 CHRONO_TZ_TIME_RANGE="1577836800..1893456000" cargo build
 ```
 
@@ -200,7 +201,7 @@ CHRONO_TZ_TIME_RANGE="1577836800.." cargo build
 CHRONO_TZ_TIME_RANGE="..1577836800" cargo build
 ```
 
-For timestamps outside the configured range, chrono-tz uses the time zone in effect at the nearest point within the configured range (for example, if your range ends on January 1, 2030, then a date in July 2035 will use whatever offset and abbreviation were in effect on January 1, 2030).
+For timestamps outside the configured range, chrono-tz will use the time zone in effect at the nearest point within the configured range. For example, if your range ends on January 1, 2030, then a date in July 2035 will use which ever was in effect on January 1, 2030.
 
 [IANA database]: http://www.iana.org/time-zones
 [wiki-list]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/bin/test-range-filtering.sh
+++ b/bin/test-range-filtering.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+export RUST_BACKTRACE=1
+export CHRONO_TZ_TIME_RANGE='1577836800..1577923200'
+
+cd chrono-tz/tests/check-range-filtering
+
+cargo test --color=always -- --color=always

--- a/chrono-tz-build/Cargo.toml
+++ b/chrono-tz-build/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/chrono-tz-build"
 
 [features]
 filter-by-regex = ["regex"]
+filter-by-range = []
 case-insensitive = ["uncased", "phf_shared/uncased"]
 regex = ["dep:regex"]
 

--- a/chrono-tz-build/src/lib.rs
+++ b/chrono-tz-build/src/lib.rs
@@ -573,7 +573,7 @@ impl TimestampRange {
                 (Some(start), None) => Ok(TimestampRange::Start(start)),
                 (None, Some(end)) => Ok(TimestampRange::End(end)),
                 (None, None) => Err(format!(
-                    "timestamp range {input:?} must have at least a start or end value, e.g. 0.. or ..2147483648"
+                    "timestamp range {input:?} must have at least a start or end value, e.g. 0.. or ..2147483648 or 0..2147483648"
                 )),
             }
     }

--- a/chrono-tz/Cargo.toml
+++ b/chrono-tz/Cargo.toml
@@ -43,6 +43,7 @@ std = []
 defmt = ["dep:defmt"]
 serde = ["dep:serde_core"]
 filter-by-regex = ["chrono-tz-build", "chrono-tz-build/filter-by-regex"]
+filter-by-range = ["chrono-tz-build", "chrono-tz-build/filter-by-range"]
 case-insensitive = ["dep:uncased", "chrono-tz-build", "chrono-tz-build/case-insensitive", "phf/uncased"]
 
 [build-dependencies]

--- a/chrono-tz/build.rs
+++ b/chrono-tz/build.rs
@@ -1,16 +1,29 @@
-#[cfg(any(feature = "filter-by-regex", feature = "case-insensitive"))]
+#[cfg(any(
+    feature = "filter-by-regex",
+    feature = "filter-by-range",
+    feature = "case-insensitive"
+))]
 use std::{env, path::Path};
 
 #[cfg(feature = "filter-by-regex")]
 use chrono_tz_build::FILTER_ENV_VAR_NAME;
+#[cfg(feature = "filter-by-range")]
+use chrono_tz_build::TIME_RANGE_ENV_VAR_NAME;
 
 fn main() {
     #[cfg(feature = "filter-by-regex")]
     println!("cargo:rerun-if-env-changed={FILTER_ENV_VAR_NAME}");
-    #[cfg(any(feature = "filter-by-regex", feature = "case-insensitive"))]
+    #[cfg(feature = "filter-by-range")]
+    println!("cargo:rerun-if-env-changed={TIME_RANGE_ENV_VAR_NAME}");
+    #[cfg(any(
+        feature = "filter-by-regex",
+        feature = "filter-by-range",
+        feature = "case-insensitive"
+    ))]
     chrono_tz_build::main(
         Path::new(&env::var("OUT_DIR").unwrap()),
         cfg!(feature = "filter-by-regex"),
+        cfg!(feature = "filter-by-range"),
         cfg!(feature = "case-insensitive"),
     );
 }

--- a/chrono-tz/src/lib.rs
+++ b/chrono-tz/src/lib.rs
@@ -135,10 +135,18 @@
 mod serde;
 
 mod binary_search;
-#[cfg(not(any(feature = "case-insensitive", feature = "filter-by-regex")))]
+#[cfg(not(any(
+    feature = "case-insensitive",
+    feature = "filter-by-regex",
+    feature = "filter-by-range"
+)))]
 use prebuilt::directory;
 mod prebuilt;
-#[cfg(any(feature = "case-insensitive", feature = "filter-by-regex"))]
+#[cfg(any(
+    feature = "case-insensitive",
+    feature = "filter-by-regex",
+    feature = "filter-by-range"
+))]
 mod directory {
     #![allow(
         dead_code,
@@ -149,9 +157,17 @@ mod directory {
     include!(concat!(env!("OUT_DIR"), "/directory.rs"));
 }
 mod timezone_impl;
-#[cfg(not(any(feature = "case-insensitive", feature = "filter-by-regex")))]
+#[cfg(not(any(
+    feature = "case-insensitive",
+    feature = "filter-by-regex",
+    feature = "filter-by-range"
+)))]
 use prebuilt::timezones;
-#[cfg(any(feature = "case-insensitive", feature = "filter-by-regex"))]
+#[cfg(any(
+    feature = "case-insensitive",
+    feature = "filter-by-regex",
+    feature = "filter-by-range"
+))]
 mod timezones {
     #![allow(non_camel_case_types, clippy::unreadable_literal)]
     include!(concat!(env!("OUT_DIR"), "/timezones.rs"));

--- a/chrono-tz/tests/check-range-filtering/Cargo.toml
+++ b/chrono-tz/tests/check-range-filtering/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "check-range-filtering"
+version = "0.1.0"
+authors = ["Moshe Dicker <dickermoshe@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+chrono = "0.4"
+chrono-tz = { path = "../../", default-features = false, features = [
+    "filter-by-range",
+] }
+
+[workspace]

--- a/chrono-tz/tests/check-range-filtering/src/lib.rs
+++ b/chrono-tz/tests/check-range-filtering/src/lib.rs
@@ -1,0 +1,31 @@
+/// This test is compiled by the Github workflows with the
+/// range filter set thusly:
+/// CHRONO_TZ_TIME_RANGE="1577836800..1577923200" (2020-01-01 UTC only).
+///
+/// We use it as an end-to-end sanity check that range filtering is
+/// actually applied in generated timezone data.
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Offset, TimeZone};
+    use chrono_tz::America::New_York;
+
+    fn offset_seconds(year: i32, month: u32, day: u32) -> i32 {
+        let dt = New_York
+            .with_ymd_and_hms(year, month, day, 12, 0, 0)
+            .single()
+            .unwrap();
+        dt.offset().fix().local_minus_utc()
+    }
+
+    #[test]
+    fn range_filtering_is_applied_end_to_end() {
+        // In this narrow winter-only range, New York should stay on EST (-5h).
+        assert_eq!(offset_seconds(2020, 1, 1), -5 * 3600);
+
+        // These dates are normally EDT (-4h), but should be pinned to EST after trimming.
+        assert_eq!(offset_seconds(2020, 7, 1), -5 * 3600);
+        assert_eq!(offset_seconds(2010, 7, 1), -5 * 3600);
+        assert_eq!(offset_seconds(2030, 7, 1), -5 * 3600);
+    }
+}

--- a/chrono-tz/tests/codegen.rs
+++ b/chrono-tz/tests/codegen.rs
@@ -8,7 +8,7 @@ fn codegen() {
     let old_timezones = fs::read_to_string(root.join("timezones.rs")).unwrap();
 
     fs::create_dir_all(&root).unwrap();
-    chrono_tz_build::main(&root, false, false);
+    chrono_tz_build::main(&root, false, false, false);
     let new_directory = fs::read_to_string(root.join("directory.rs")).unwrap();
     let new_timezones = fs::read_to_string(root.join("timezones.rs")).unwrap();
 


### PR DESCRIPTION
This PR adds support for shrinking the generated time zone database by limiting the time window spans are generated for. This is mainly for size-constrained builds.

Usage:
```sh
#  If you only care about 2020-01-01 through 2030-01-01 UTC:
CHRONO_TZ_TIME_RANGE="1577836800..1893456000" cargo build --features filter-by-range
```

You can also do open-ended ranges:
```sh
# from 2020 onward
CHRONO_TZ_TIME_RANGE="1577836800.." cargo build --features filter-by-range
```
```sh
# up to 2020
CHRONO_TZ_TIME_RANGE="..1577836800" cargo build --features filter-by-range
```

Tests have been added for the range filtering specifically and as an end-to-end in `tests/check-range-filtering`